### PR TITLE
Update TimeIntervalPicker.swift

### DIFF
--- a/TimeIntervalPicker/Classes/TimeIntervalPicker.swift
+++ b/TimeIntervalPicker/Classes/TimeIntervalPicker.swift
@@ -276,7 +276,7 @@ open class TimeIntervalPicker: UIView, UIPickerViewDelegate, UIPickerViewDataSou
                 self.pickerView?.selectRow(hour, inComponent: 0, animated: true)
                 self.pickerView?.selectRow(minute, inComponent: 1, animated: true)
             } else {
-                self.pickerView?.selectRow(minute, inComponent: 0, animated: true)
+                self.pickerView?.selectRow(minute, inComponent: 1, animated: true)
             }
         }
         


### PR DESCRIPTION
Fixed a bug where the picker would set the hour component instead of the minute when selectedMinute < 60